### PR TITLE
Add Backwards Compatibility and Code Formatting

### DIFF
--- a/EDD_License_Handler.php
+++ b/EDD_License_Handler.php
@@ -49,7 +49,7 @@ class EDD_License {
 		 * handler will automatically pick these up and use those in lieu of the
 		 * user having to reactive their license.
 		 */
-		if ( ! empty( $_optname ) && isset( $edd_options[ $_optname ] ) && empty( $this->license ) ) ) {
+		if ( ! empty( $_optname ) && isset( $edd_options[ $_optname ] ) && empty( $this->license ) ) {
 			$this->license = trim( $edd_options[ $_optname ] );
 		}
 


### PR DESCRIPTION
Allow plugins to add the option name where the license key used to be allowing for backwards compatibility and also format code to follow the WordPress Coding Standards.
