### PR TITLE
Fix error in plugin information view

### DIFF
--- a/EDD_SL_Plugin_Updater.php
+++ b/EDD_SL_Plugin_Updater.php
@@ -279,8 +279,8 @@ class EDD_SL_Plugin_Updater {
 		// Convert sections into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->sections ) && ! is_array( $_data->sections ) ) {
 			$new_sections = array();
-			foreach ( $_data->sections as $key => $key ) {
-				$new_sections[ $key ] = $key;
+			foreach ( $_data->sections as $key => $value ) {
+				$new_sections[ $key ] = $value;
 			}
 
 			$_data->sections = $new_sections;
@@ -289,8 +289,8 @@ class EDD_SL_Plugin_Updater {
 		// Convert banners into an associative array, since we're getting an object, but Core expects an array.
 		if ( isset( $_data->banners ) && ! is_array( $_data->banners ) ) {
 			$new_banners = array();
-			foreach ( $_data->banners as $key => $key ) {
-				$new_banners[ $key ] = $key;
+			foreach ( $_data->banners as $key => $value ) {
+				$new_banners[ $key ] = $value;
 			}
 
 			$_data->banners = $new_banners;


### PR DESCRIPTION
The current version of the EDD_SL_Plugin_Udpater class has an error where the first click on "View version x.x.x details" shows all the data properly, but all subsequent checks return only the  section keys.

**First click**

![](https://cloud.githubusercontent.com/assets/2084481/23260204/007be5fe-f9d1-11e6-8189-ef7ac30e89b1.png)

**Second and next clicks**

![](https://cloud.githubusercontent.com/assets/2084481/23260229/19db2dc0-f9d1-11e6-93e0-1577b26d6b64.png)

When plugin information is fetched, all plugin data is displayed properly. But after the cache is set, section and banner keys are used instead of the data.

This pull request should fix this.