### PR TITLE
Fix single site plugins view in multisite environment

### DIFF
--- a/EDD_SL_Plugin_Updater.php
+++ b/EDD_SL_Plugin_Updater.php
@@ -186,13 +186,15 @@ class EDD_SL_Plugin_Updater {
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ) );
 
 		if ( ! empty( $update_cache->response[ $this->name ] ) && version_compare( $this->version, $version_info->new_version, '<' ) ) {
+			$active_class = is_plugin_active( $file ) ? ' active' : '';
 
 			// build a plugin list row, with update notification
 			$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
 			# <tr class="plugin-update-tr"><td colspan="' . $wp_list_table->get_column_count() . '" class="plugin-update colspanchange">
-			echo '<tr class="plugin-update-tr" id="' . $this->slug . '-update" data-slug="' . $this->slug . '" data-plugin="' . $this->slug . '/' . $file . '">';
+			echo '<tr class="plugin-update-tr' . $active_class . '" id="' . $this->slug . '-update" data-slug="' . $this->slug . '" data-plugin="' . $this->slug . '/' . $file . '">';
 			echo '<td colspan="3" class="plugin-update colspanchange">';
 			echo '<div class="update-message notice inline notice-warning notice-alt">';
+			echo '<p>';
 
 			$changelog_link = self_admin_url( 'index.php?edd_sl_action=view_plugin_changelog&plugin=' . $this->name . '&slug=' . $this->slug . '&TB_iframe=true&width=772&height=911' );
 
@@ -218,7 +220,7 @@ class EDD_SL_Plugin_Updater {
 
 			do_action( "in_plugin_update_message-{$file}", $plugin, $version_info );
 
-			echo '</div></td></tr>';
+			echo '</p></div></td></tr>';
 		}
 	}
 


### PR DESCRIPTION
To display a changelog link in the plugin view for a single site in a multisite environment, the current version of the EDD_SL_Plugin_Updater class uses a custom `edd_sl_action` request parameter that is catched by an action on `admin_init` to display a custom changelog with `show_changelog()`.

This pull request
* simplifies the changelog link by using default functionality for displaying changelogs. The `show_changelog()` method would not be used anymore and could be removed.
* optimizes the update link in the same manner, so that the user gets taken to the network plugins page after updating instead of the single site plugin view.
* Brings the styles of the updates closer to how they normally look in WordPress.

I hope I didn’t miss any case where these changes break everything. It probably needs some testing.

I’m also not sure if this feature is still needed at all? WordPress doesn’t show any update notifications for single site plugin lists in a multisite environment. When only those plugins show an update that use the EDD plugin updater, wouldn’t this leave the user under the impression that all other plugins do not have any updates? On the other hand, when the plugin is being updated, the user is taken to the network plugins page where he might see other updates.