### PR TITLE
api_request() should always return false|object

### DIFF
--- a/EDD_SL_Plugin_Updater.php
+++ b/EDD_SL_Plugin_Updater.php
@@ -334,7 +334,7 @@ class EDD_SL_Plugin_Updater {
 		$data = array_merge( $this->api_data, $_data );
 
 		if ( $data['slug'] != $this->slug ) {
-			return;
+			return false;
 		}
 
 		if( $this->api_url == trailingslashit (home_url() ) ) {


### PR DESCRIPTION
This causes unexpected results such as loading the wrong plugin readme if multiple plugins are using EDD-License-handler.

Fixes #38.